### PR TITLE
Fix Maven module names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
-		<module>flux-flix-client</module>
-		<module>flux-flix-service</module>
+		<module>ffs-client</module>
+		<module>ffs-service</module>
 	</modules>
 </project>


### PR DESCRIPTION
It seems that 2dd7450 broke the module structure.
Prior to this change a simple `./mvnw clean compile` would fail