### PR TITLE
Switch from using Streams API to pure Reactor

### DIFF
--- a/ffs-service/src/main/java/com/example/FfsServiceApplication.java
+++ b/ffs-service/src/main/java/com/example/FfsServiceApplication.java
@@ -206,11 +206,11 @@ class MovieDataCLR implements CommandLineRunner {
     public void run(String... strings) throws Exception {
         this.movieRepository
                 .deleteAll()
-                .subscribe(null, null, () ->
-                        Stream.of("Flux Gordon", "Enter the Mono<Void>", "Back to the Future", "AEon Flux")
-                                .map(title -> new Movie(UUID.randomUUID().toString(), title))
-                                .forEach(movie -> movieRepository.save(movie)
-                                        .subscribe(m -> log.info(m.toString()))));
+                .thenMany(Flux.just("Flux Gordon", "Enter the Mono<Void>", "Back to the Future", "AEon Flux"))
+                .map(title -> new Movie(UUID.randomUUID().toString(), title))
+                .flatMap(movie -> movieRepository.save(movie))
+                .doOnNext(m -> log.info("Saved movie \u001B[32m" + m.getTitle() + "\u001B[0m (id=" + m.getId() + ")"))
+                .blockLast();
     }
 }
 

--- a/ffs-service/src/main/java/com/example/FfsServiceApplication.java
+++ b/ffs-service/src/main/java/com/example/FfsServiceApplication.java
@@ -163,6 +163,7 @@ class FluxFlixRestController {
 }
 */
 
+@Log
 @Service
 class FluxFlixService {
 
@@ -173,8 +174,13 @@ class FluxFlixService {
     }
 
     public Flux<MovieEvent> streamStreams(Movie movie) {
-        return Flux.fromStream(Stream.generate(() -> new MovieEvent(movie, new Date())))
-                .delayElements(Duration.ofSeconds(1));
+        return Flux.<MovieEvent>generate(sink -> sink.next(new MovieEvent(movie, new Date())))
+                   .delayElements(Duration.ofSeconds(1))
+        //alternatively:
+//        return Flux.interval(Duration.ofSeconds(1))
+//                .map(ignore -> new MovieEvent(movie, new Date()));
+                .doFinally(s -> log.info("Streaming info on '" + movie.getTitle() +
+                        "' ended: " + s));
     }
 
     public Flux<Movie> all() {


### PR DESCRIPTION
In this PR I changed the service (java implementation) so that it uses pure Reactor patterns instead of a mix of Reactor and Java 8 Streams.

By itself, use of Streams within a reactive app is not a bad thing, but in the CLR having a stream inside a subscribe felt particularly clunky.
The other changes still makes the whole processing more readable IMHO.

I also changed the streamStreams method to show that Reactor can also `generate` a Flux.
I added an alternative method that starts from the time interval rather than delaying elements after they're generated (so that it ends up generating events at an exact rate of one per second).
Then I added a log that shows in the Service console whenever the client terminates reading the stream.

Finally, a :gift: for @joshlong: **colors in console logs** :smile: (init of db shows the saved movie names in ANSI color)